### PR TITLE
Support symbolic links.

### DIFF
--- a/crc32.cpp
+++ b/crc32.cpp
@@ -25,10 +25,12 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <string.h>
 #endif
 
 #include <iostream>
 
+#include "crc32.hpp"
 #include "crc32_poly.hpp"
 
 using namespace std;
@@ -132,4 +134,20 @@ uint32_t calc_crc32( const char * file_path ) {
 #endif
   /* invert all bits */
   return crc ^ 0xffffffff;
+}
+
+uint32_t calc_str_crc32(const char * str) {
+    size_t num_bytes = strlen(str);
+    uint32_t crc = 0;
+    for (size_t i = 0; i < num_bytes; ++i) {
+        crc = crc_table[str[i] ^ ((crc >> 24) & 0xFF)] ^ (crc << 8);
+    }
+
+    /* cksum.c also calculates the crc-32 on the length of the file */
+    while (num_bytes > 0) {
+        crc = crc_table[(((uint64_t) num_bytes) & 0xFF) ^ ((crc >> 24) & 0xFF)] ^ (crc << 8);
+        num_bytes >>= 8;
+    }
+
+    return crc ^ 0xffffffff;
 }

--- a/crc32.hpp
+++ b/crc32.hpp
@@ -19,5 +19,8 @@
 */
 #pragma once
 
+#include <stdint.h>
+
 uint32_t calc_crc32( const char * file_path );
 
+uint32_t calc_str_crc32(const char * str);

--- a/ls4mkbom.1
+++ b/ls4mkbom.1
@@ -11,8 +11,6 @@ ls4mkbom prints a list of file and folders contained in the directory specified 
 .SH SEE ALSO
 mkbom(1), lsbom(1), dumpbom(1)
 .SH BUGS
-Symbolic links are not supported
-.PP
 Long paths and some characters in filenames will cause ls4mkbom to fail on Windows.
 .SH AUTHOR
 Fabian Renn (fabian.renn@gmail.com)

--- a/mkbom.1
+++ b/mkbom.1
@@ -14,8 +14,6 @@ create a bill-of-materials file from the text file specified with 'source' which
 .SH SEE ALSO
 lsbom(1), ls4mkbom(1), dumpbom(1)
 .SH BUGS
-Symbolic links are not supported
-.PP
 Long paths and some characters in filenames will cause mkbom to fail on Windows.
 .SH AUTHOR
 Fabian Renn (fabian.renn@gmail.com)


### PR DESCRIPTION
The following changes were made to support symbolic links:
- Provide a function to compute the CRC32 of a string
- Use lstat instead of stat so that printnode will detect symbolic links instead of following them
- Have printnode print the size, CRC and contents of the link
- Have mkbom store symlinks in the BOM
- Remove the symlink restriction from the BUGS section of the ls4mkbom and mkbom man pages
