### PR TITLE
Add support for large bom files (fixes #2)

### DIFF
--- a/src/bom.h
+++ b/src/bom.h
@@ -98,8 +98,8 @@ struct BOMVars {
 
 
 struct BOMPathIndices {
-  uint32_t index0;
-  uint32_t index1;
+  uint32_t index0; /* for leaf: points to BOMPathInfo1, for branch points to BOMPaths */
+  uint32_t index1; /* always points to BOMFile */
 } __attribute__((packed));
 
 


### PR DESCRIPTION
This adds support for larger bom files (more than 512 files). I've tested this on several Mac OS X versions and it's working for me.

The fix involves putting max 256 file into one BOMPaths structure and then referencing each BOMPaths structure in a root BOMPaths (isLeaf=0) structure. The BOMPathIndices entries in the root BOMPaths point to the child BOMPaths (BOMPathIndices->index0) and to the last BOMFileInfo in that child BOMPaths (BOMPathIndices->index1).

The code could definitely use some cleanup and more testing.
