### PR TITLE
Remove CNAME with bomutils.dyndns.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-bomutils.dyndns.org


### PR DESCRIPTION
`bomutils.dyndns.org` seems to have expired or something, which is unfortunate, because a lot of pages link to the nice tutorial that you wrote.

I removed the `CNAME` file so that you can push to GitHub Pages at https://hogliux.github.io/bomutils, if you'd like.

I've made this change on my own fork, so your pages can be viewed at https://msabramo.github.io/bomutils/tutorial.html, though I don't want people to think that this is my project and not yours, so I think it would be better if you got your site working again.