### PR TITLE
fix: error reference to ‘data’ is ambiguous

### DIFF
--- a/src/lsbom.cpp
+++ b/src/lsbom.cpp
@@ -55,7 +55,7 @@ enum {
 
 
 static int debug = 0;
-static char *data;
+static char *lsbomData;
 static BOMBlockTable *indexHeader;
 
 char *lookup(int i, uint32_t *length = 0) {
@@ -67,7 +67,7 @@ char *lookup(int i, uint32_t *length = 0) {
         << " addr=0x" << hex << setw(4) << setfill('0') << addr
         << " len=" << dec << ntohl(index->length));
 
-  return data + addr;
+  return lsbomData + addr;
 }
 
 
@@ -234,10 +234,10 @@ int main(int argc, char *argv[]) {
     }
 
     // Allocate space
-    data = new char[length];
+    lsbomData = new char[length];
 
-    // Read data
-    f.read(data, length);
+    // Read lsbomData
+    f.read(lsbomData, length);
 
     if (f.fail()) {
       cerr << "Failed to read BOM file" << endl;
@@ -246,17 +246,17 @@ int main(int argc, char *argv[]) {
 
     f.close();
 
-    BOMHeader *header = (BOMHeader *)data;
+    BOMHeader *header = (BOMHeader *)lsbomData;
 
     if (string(header->magic, 8) != "BOMStore") {
       cerr << "Not a BOM file: " << argv[i] << endl;
       return 1;
     }
 
-    indexHeader = (BOMBlockTable *)(data + ntohl(header->indexOffset));
+    indexHeader = (BOMBlockTable *)(lsbomData + ntohl(header->indexOffset));
 
     // Process vars
-    BOMVars *vars = (BOMVars *)(data + ntohl(header->varsOffset));
+    BOMVars *vars = (BOMVars *)(lsbomData + ntohl(header->varsOffset));
     char *ptr = (char *)vars->first;
     for (unsigned i = 0; i < ntohl(vars->count); i++) {
       BOMVar *var = (BOMVar *)ptr;


### PR DESCRIPTION
bomutils was compiling fine on ubuntu 20.04 but it fails with ubuntu 22.04 (maybe the compiler has been upgraded and is more picky) with the error : 

```
src/lsbom.cpp:70:10: error: reference to ‘data’ is ambiguous                                                                                                                                                       
   70 |   return data + addr;                                                                                                                                                                                      
      |          ^~~~                                                                                                                                                                                              
In file included from /usr/include/c++/11/string:54,                                                                                                                                                               
                 from /usr/include/c++/11/bits/locale_classes.h:40,                                                                                                                                                
                 from /usr/include/c++/11/bits/ios_base.h:41,                                                                                                                                                      
                 from /usr/include/c++/11/ios:42,                                                                                                                                                                  
                 from /usr/include/c++/11/ostream:38,                                                                                                                                                              
                 from /usr/include/c++/11/iostream:39,                                                                                                                                                             
                 from src/lsbom.cpp:25:                                                                                                                                                                            
/usr/include/c++/11/bits/range_access.h:319:5: note: candidates are: ‘template<class _Tp> constexpr const _Tp* std::data(std::initializer_list<_Tp>)’
  319 |     data(initializer_list<_Tp> __il) noexcept
      |     ^~~~
/usr/include/c++/11/bits/range_access.h:310:5: note:                 ‘template<class _Tp, long unsigned int _Nm> constexpr _Tp* std::data(_Tp (&)[_Nm])’
  310 |     data(_Tp (&__array)[_Nm]) noexcept
      |     ^~~~
/usr/include/c++/11/bits/range_access.h:300:5: note:                 ‘template<class _Container> constexpr decltype (__cont.data()) std::data(const _Container&)’
  300 |     data(const _Container& __cont) noexcept(noexcept(__cont.data()))
      |     ^~~~
/usr/include/c++/11/bits/range_access.h:290:5: note:                 ‘template<class _Container> constexpr decltype (__cont.data()) std::data(_Container&)’
  290 |     data(_Container& __cont) noexcept(noexcept(__cont.data()))
      |     ^~~~
```

We just have changed the variable name.