### PR TITLE
Avoid buffer overflow when node.linkNameLength is 0

### DIFF
--- a/src/mkbom.cpp
+++ b/src/mkbom.cpp
@@ -396,7 +396,7 @@ void write_bom( istream & lsbom_file, const string & output_path ) {
         info2->unknown1 = 1;
         info2->checksum = htonl(node.checksum);
         info2->linkNameLength = htonl(node.linkNameLength);
-        strcpy( info2->linkName, node.linkName.c_str() );
+        strncpy( info2->linkName, node.linkName.c_str(), node.linkNameLength );
 
         BOMPathInfo1 info1;
         info1.id = htonl( j + 1 );


### PR DESCRIPTION
mkbom would crash because the `strcpy` would copy the null terminator of the (empty) `node.linkName` for elements whose mode are not `0xA000` (and thus have linknamelength = 0, hence no space for even a null terminator in linkName).

We avoid this by using `strncpy` to limit the number of bytes we copy from `linkName` to `linkNameLength`.